### PR TITLE
Player Controller Delay

### DIFF
--- a/project/player/player_controller.gd
+++ b/project/player/player_controller.gd
@@ -20,6 +20,7 @@ var landed = false
 var jump_from_breach: bool = false
 var water_layer: int = 4
 var breach_layer: int = 8
+var just_jumped = false
 @export var player_state: PlayerState = PlayerState.water
 
 
@@ -31,6 +32,8 @@ func _on_jump(angle: float, power: float):
   match player_state:
     PlayerState.land:
       if is_on_floor():
+        just_jumped = true
+        just_jumped_delay()
         var direction = Vector2(cos(angle), sin(angle))
         
         var v_x = direction.x * power * base_jump_velocity
@@ -75,8 +78,8 @@ func _physics_process(delta: float) -> void:
         if not landed:
           $frog_hop_audio._play_landing(false)
           landed = true
-      
-        velocity.x *= damping_factor
+        if not just_jumped:
+          velocity.x *= damping_factor
         if abs(velocity.x) < 0.1:
           velocity.x = 0
     PlayerState.water:
@@ -129,5 +132,8 @@ func _on_water_detector_area_exited(area):
       velocity = Vector2.ZERO
       breached.emit()
       #print("entering breached - play breaching water sound here")
-      
-    
+
+func just_jumped_delay():
+  await get_tree().create_timer(0.1).timeout
+  just_jumped = false
+  

--- a/project/trajectory/trajectory.gd
+++ b/project/trajectory/trajectory.gd
@@ -2,6 +2,7 @@ extends Line2D
 
 @onready var jump_arrow: JumpArrow = %JumpArrow
 @export var player: PlayerCharacter
+@export var use_on_all_jumps: bool = false
 const MAX_POINTS = 50
 var gravity: float = 980 # need to get this from engine
 var base_jump_velocity = -10.0 # need to get this from player
@@ -34,7 +35,7 @@ func _physics_process(delta):
 
 func _on_update_trajectory(angle: float, speed: float):
   var direction = Vector2(cos(angle), sin(angle))
-  if player_state_breached:
+  if player_state_breached or use_on_all_jumps:
     show_trajectory = true
     trajectory_vel = direction * speed * base_jump_velocity * water_jump_boost
     update_trajectory = true


### PR DESCRIPTION
This is a purposed change to the character controller, now there is a small delay on ground friction and this stops the x velocity from being variable dampened on launch. I think this makes the player feel like they are going where they are pointing. 

Didn't attach a video because it really is more about the feel of jumping off a platform. The velocity is now applied to the frog as expected. My implementation is a little jank but it does do the trick. Only jumping off of land is affected by this pull request